### PR TITLE
replacing deprecated convert command with new magick 

### DIFF
--- a/i3lockmore
+++ b/i3lockmore
@@ -16,9 +16,12 @@ USE_IMAGE_MAXIMIZE=false
 IMAGE=
 USE_LOCK_ICON=false
 LOCK_ICON="/usr/share/i3lockmore/lock-icon.png"
-MAGICK_CMD=$(which magick)
-MAGICK_CMD=$([ -f "$MAGICK_CMD" ] && [ ! -L "$MAGICK_CMD" ] && echo "$MAGICK_CMD" || $(which convert))
 
+MAGICK_CMD=$(which convert)
+if [ -L "$MAGICK_CMD" ] 
+then 
+	MAGICK_CMD=$(which magick)
+fi
 
 function print_help {
 cat <<- EOF

--- a/i3lockmore
+++ b/i3lockmore
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+
 USE_PIXELATE=false
 PIXELATE_SCALEFACTOR=4
 USE_DPMS=false
@@ -16,11 +17,9 @@ USE_IMAGE_MAXIMIZE=false
 IMAGE=
 USE_LOCK_ICON=false
 LOCK_ICON="/usr/share/i3lockmore/lock-icon.png"
+MAGICK_CMD=$(command -v convert)
+[ ! -L "$MAGICK_CMD" ] || MAGICK_CMD=$(command -v magick)
 
-MAGICK_CMD=$(which convert)
-[ ! -L "$MAGICK_CMD" ] || MAGICK_CMD=$(which magick)
-
-exit 1
 function print_help {
 cat <<- EOF
 Extension for the screenlocker "i3lock" adding some high-level features:

--- a/i3lockmore
+++ b/i3lockmore
@@ -18,11 +18,9 @@ USE_LOCK_ICON=false
 LOCK_ICON="/usr/share/i3lockmore/lock-icon.png"
 
 MAGICK_CMD=$(which convert)
-if [ -L "$MAGICK_CMD" ] 
-then 
-	MAGICK_CMD=$(which magick)
-fi
+[ ! -L "$MAGICK_CMD" ] || MAGICK_CMD=$(which magick)
 
+exit 1
 function print_help {
 cat <<- EOF
 Extension for the screenlocker "i3lock" adding some high-level features:

--- a/i3lockmore
+++ b/i3lockmore
@@ -172,11 +172,11 @@ if [[ "$USE_IMAGE_FILL" == true ]]; then
     screenarea=${screenarea// /}
     screens=( $(xrandr --current | grep -oP '\d+x\d+\+\d+\+\d+') )
 
-    convert -size $screenarea xc:black $GRAYSCALE -quality 11 png24:"$BACKGROUND"
+    magick -size $screenarea xc:black $GRAYSCALE -quality 11 png24:"$BACKGROUND"
 
     if check_file_exists "$IMAGE"; then
         for screen in "${screens[@]}"; do
-            convert "$BACKGROUND" \
+            magick "$BACKGROUND" \
                 \( "$IMAGE" -gravity Center -resize ${screen%%+*}^ -extent ${screen%%+*} \) \
                 -gravity NorthWest -geometry +${screen#*+} -composite \
                 $GRAYSCALE -quality 11 png24:"$BACKGROUND"
@@ -192,10 +192,10 @@ if [[ "$USE_IMAGE_MAXIMIZE" == true ]]; then
     screenarea=${screenarea// /}
 
     if check_file_exists "$IMAGE"; then
-        convert "$IMAGE" -gravity Center -resize $screenarea^ -extent $screenarea \
+        magick "$IMAGE" -gravity Center -resize $screenarea^ -extent $screenarea \
             $GRAYSCALE -quality 11 png24:"$BACKGROUND"
     else
-        convert -size $screenarea xc:black $GRAYSCALE -quality 11 png24:"$BACKGROUND"
+        magick -size $screenarea xc:black $GRAYSCALE -quality 11 png24:"$BACKGROUND"
     fi
 fi
 
@@ -204,7 +204,7 @@ if [[ "$USE_BLUR" == true ]]; then
     make_screenshot
 
     size=$(identify -format "%[fx:w]x%[fx:h]" "$BACKGROUND")
-    convert "$BACKGROUND" -scale $BLUR_FACTOR% $GRAYSCALE -resize $size\! -quality 11 png24:"$BACKGROUND"
+    magick "$BACKGROUND" -scale $BLUR_FACTOR% $GRAYSCALE -resize $size\! -quality 11 png24:"$BACKGROUND"
 fi
 
 
@@ -212,7 +212,7 @@ if [[ "$USE_PIXELATE" == true ]]; then
     make_screenshot
 
     size=$(identify -format "%[fx:w]x%[fx:h]" "$BACKGROUND")
-    convert "$BACKGROUND" -scale $PIXELATE_SCALEFACTOR% $GRAYSCALE -sample $size\! -quality 11 png24:"$BACKGROUND"
+    magick "$BACKGROUND" -scale $PIXELATE_SCALEFACTOR% $GRAYSCALE -sample $size\! -quality 11 png24:"$BACKGROUND"
 fi
 
 
@@ -223,7 +223,7 @@ if [[ "$USE_LOCK_ICON" == true ]]; then
 
     if check_file_exists "$LOCK_ICON"; then
         for screen in "${screens[@]}"; do
-            convert "$BACKGROUND" \
+            magick "$BACKGROUND" \
                 \( "$LOCK_ICON" -gravity Center -background none -extent ${screen%%+*} \) \
                 -gravity NorthWest -geometry +${screen#*+} -composite \
                 $GRAYSCALE -quality 11 png24:"$BACKGROUND"

--- a/i3lockmore
+++ b/i3lockmore
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-
 USE_PIXELATE=false
 PIXELATE_SCALEFACTOR=4
 USE_DPMS=false
@@ -17,6 +16,8 @@ USE_IMAGE_MAXIMIZE=false
 IMAGE=
 USE_LOCK_ICON=false
 LOCK_ICON="/usr/share/i3lockmore/lock-icon.png"
+MAGICK_CMD=$(which magick)
+MAGICK_CMD=$([ -f "$MAGICK_CMD" ] && [ ! -L "$MAGICK_CMD" ] && echo "$MAGICK_CMD" || $(which convert))
 
 
 function print_help {
@@ -172,18 +173,17 @@ if [[ "$USE_IMAGE_FILL" == true ]]; then
     screenarea=${screenarea// /}
     screens=( $(xrandr --current | grep -oP '\d+x\d+\+\d+\+\d+') )
 
-    magick -size $screenarea xc:black $GRAYSCALE -quality 11 png24:"$BACKGROUND"
+    "$MAGICK_CMD" -size $screenarea xc:black $GRAYSCALE -quality 11 png24:"$BACKGROUND"
 
     if check_file_exists "$IMAGE"; then
         for screen in "${screens[@]}"; do
-            magick "$BACKGROUND" \
+            "$MAGICK_CMD" "$BACKGROUND" \
                 \( "$IMAGE" -gravity Center -resize ${screen%%+*}^ -extent ${screen%%+*} \) \
                 -gravity NorthWest -geometry +${screen#*+} -composite \
                 $GRAYSCALE -quality 11 png24:"$BACKGROUND"
         done
     fi
 fi
-
 
 if [[ "$USE_IMAGE_MAXIMIZE" == true ]]; then
     get_background_file
@@ -192,10 +192,10 @@ if [[ "$USE_IMAGE_MAXIMIZE" == true ]]; then
     screenarea=${screenarea// /}
 
     if check_file_exists "$IMAGE"; then
-        magick "$IMAGE" -gravity Center -resize $screenarea^ -extent $screenarea \
+        "$MAGICK_CMD" "$IMAGE" -gravity Center -resize $screenarea^ -extent $screenarea \
             $GRAYSCALE -quality 11 png24:"$BACKGROUND"
     else
-        magick -size $screenarea xc:black $GRAYSCALE -quality 11 png24:"$BACKGROUND"
+        "$MAGICK_CMD" -size $screenarea xc:black $GRAYSCALE -quality 11 png24:"$BACKGROUND"
     fi
 fi
 
@@ -204,7 +204,7 @@ if [[ "$USE_BLUR" == true ]]; then
     make_screenshot
 
     size=$(identify -format "%[fx:w]x%[fx:h]" "$BACKGROUND")
-    magick "$BACKGROUND" -scale $BLUR_FACTOR% $GRAYSCALE -resize $size\! -quality 11 png24:"$BACKGROUND"
+    "$MAGICK_CMD" "$BACKGROUND" -scale $BLUR_FACTOR% $GRAYSCALE -resize $size\! -quality 11 png24:"$BACKGROUND"
 fi
 
 
@@ -212,7 +212,7 @@ if [[ "$USE_PIXELATE" == true ]]; then
     make_screenshot
 
     size=$(identify -format "%[fx:w]x%[fx:h]" "$BACKGROUND")
-    magick "$BACKGROUND" -scale $PIXELATE_SCALEFACTOR% $GRAYSCALE -sample $size\! -quality 11 png24:"$BACKGROUND"
+    "$MAGICK_CMD" "$BACKGROUND" -scale $PIXELATE_SCALEFACTOR% $GRAYSCALE -sample $size\! -quality 11 png24:"$BACKGROUND"
 fi
 
 
@@ -223,11 +223,12 @@ if [[ "$USE_LOCK_ICON" == true ]]; then
 
     if check_file_exists "$LOCK_ICON"; then
         for screen in "${screens[@]}"; do
-            magick "$BACKGROUND" \
+            "$MAGICK_CMD" "$BACKGROUND" \
                 \( "$LOCK_ICON" -gravity Center -background none -extent ${screen%%+*} \) \
                 -gravity NorthWest -geometry +${screen#*+} -composite \
                 $GRAYSCALE -quality 11 png24:"$BACKGROUND"
         done
+
     fi
 fi
 


### PR DESCRIPTION
WARNING: The convert command is deprecated in IMv7, use "magick" instead of "convert" or "magick convert" is printed on command line on execution. Sometime in the future this will stop working 

Would be nice if it can continue to live